### PR TITLE
Update trim 0.0.1 -> 0.0.3

### DIFF
--- a/tests/deps/trim/package.json
+++ b/tests/deps/trim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trim",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "repo": "nami-doc/trim.c",
   "license": "MIT",
   "src": ["trim.c", "trim.h"]


### PR DESCRIPTION
Nodejs (npm) Security Update for trim (GHSA-w5p7-h5w8-2hfq)

All versions of package trim lower than 0.0.3 are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().

This should be taken up by mathematical in it's dependencies update to create `1.6.15`