### PR TITLE
Update to account for C prototype changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ CMakeFiles
 CMakeCache.txt
 Release
 Win32
+
+Testing/

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -1523,12 +1523,12 @@ int display_style = 0;
 
 %%
 
-void mtex2MML_restart ()
+void mtex2MML_restart (void)
 {
   BEGIN(INITIAL);
 }
 
-void mtex2MML_reset_parsing_environment()
+void mtex2MML_reset_parsing_environment(void)
 {
   parsing_environment = NO_PARSE;
   mtex2MML_eqn_src[mtex2MML_eqn_end-mtex2MML_eqn_src-yyleng]=0;
@@ -1548,7 +1548,7 @@ void mtex2MML_setup (const char * buffer, unsigned long length)
   s_mtex2MML_length = length;
 }
 
-int mtex2MML_capture_eqn_src()
+int mtex2MML_capture_eqn_src(void)
 {
   if (YY_START != INITIAL && YY_START != SVGENV)
     return mtex2MML_do_capture_eqn();
@@ -1556,7 +1556,7 @@ int mtex2MML_capture_eqn_src()
   return -1;
 }
 
-int mtex2MML_do_capture_eqn()
+int mtex2MML_do_capture_eqn(void)
 {
   if (mtex2MML_eqn_bufsize - (mtex2MML_eqn_end-mtex2MML_eqn_src+yyleng) > 1)
   {

--- a/src/mtex2MML.h
+++ b/src/mtex2MML.h
@@ -51,24 +51,24 @@ extern void (*mtex2MML_error) (const char * msg);                          /* de
 
 extern char * mtex2MML_global_parse (const char * buffer, unsigned long length, const int options, const int global_start);
 
-extern int mtex2MML_delimiter_type();
+extern int mtex2MML_delimiter_type(const int type);
 
 extern void   mtex2MML_setup (const char * buffer, unsigned long length);
 
-extern void   mtex2MML_restart ();
-extern void   mtex2MML_reset_parsing_environment ();
+extern void   mtex2MML_restart (void);
+extern void   mtex2MML_reset_parsing_environment (void);
 
-extern int mtex2MML_do_capture_eqn();
-extern int mtex2MML_capture_eqn_src();
+extern int mtex2MML_do_capture_eqn(void);
+extern int mtex2MML_capture_eqn_src(void);
 
-extern char * mtex2MML_output ();
+extern char * mtex2MML_output (void);
 
 extern char * mtex2MML_copy_string (const char * str);
 extern char * mtex2MML_copy_string_extra (const char * str, unsigned extra);
 extern char * mtex2MML_copy2 (const char * first, const char * second);
 extern char * mtex2MML_copy3 (const char * first, const char * second, const char * third);
 extern char * mtex2MML_copy_escaped (const char * str);
-extern  UT_array ** mtex2MML_get_environment_data_stack();
+extern  UT_array ** mtex2MML_get_environment_data_stack(void);
 
 extern char * mtex2MML_empty_string;
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -36,7 +36,7 @@ yydebug = 1;
 
  encaseType encase = NONE;
 
- extern int yylex ();
+ extern int yylex (void);
 
  extern char * yytext;
 
@@ -86,7 +86,7 @@ yydebug = 1;
  #ifdef mtex2MML_CAPTURE
  static char * mtex2MML_output_string = "" ;
 
- char * mtex2MML_output ()
+ char * mtex2MML_output (void)
  {
    char * copy = (char *) malloc((mtex2MML_output_string ? strlen(mtex2MML_output_string) : 0) + 1);
    if (copy) {
@@ -279,7 +279,7 @@ yydebug = 1;
  }
 
  /* Returns a string representation of the global_label, and increments the label */
- char * mtex2MML_global_label()
+ char * mtex2MML_global_label(void)
  {
    char * n = (char *) malloc(256);
    #ifdef _WIN32
@@ -3507,7 +3507,7 @@ void format_additions(const char *buffer, const int options)
   encase = (encaseType) encase_pointer;
 }
 
-void free_additions()
+void free_additions(void)
 {
   utarray_free(environment_data_stack);
 
@@ -3553,7 +3553,7 @@ char * mtex2MML_parse (const char * buffer, unsigned long length, const int opti
   return mathml;
 }
 
-UT_array ** mtex2MML_get_environment_data_stack()
+UT_array ** mtex2MML_get_environment_data_stack(void)
 {
   return &environment_data_stack;
 }

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -411,7 +411,7 @@ clar_test_init(int argc, char **argv)
 }
 
 int
-clar_test_run()
+clar_test_run(void)
 {
 	if (_clar.argc > 1)
 		clar_parse_args(_clar.argc, _clar.argv);
@@ -426,7 +426,7 @@ clar_test_run()
 }
 
 void
-clar_test_shutdown()
+clar_test_shutdown(void)
 {
 	clar_print_shutdown(
 		_clar.tests_ran,


### PR DESCRIPTION
"a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]"